### PR TITLE
Corrected hard coded to .PI

### DIFF
--- a/data/conky/setconky
+++ b/data/conky/setconky
@@ -22,7 +22,7 @@ CALL=$(cat ~/.conkyrc | grep "{color Yellow}" | sed s'/.*{alignc}//' | head -1)
 CALL=$(echo ${INFO} | awk -F "|" '{print $1}')
 
 for files in ${CONFIG_FILES}; do
-	echo -e "\n$files" | awk -F "/" '{print $NF}' | sed 's/.pi//'
+	echo -e "\n$files" | awk -F "/" '{print $NF}' | sed 's/'$TYPE'//'
 done | yad --width=550 --height=400 --title="Conky Prefs" --image=$LOGO \
             --center --list --print-all --checklist --grid-lines=hor \
             --column="" --column="File Name" \


### PR DESCRIPTION
Setconky had one line hard coded to .PI - and thus didn't change configs under Debian.  Changed it to use $TYPE to allow it to work under Debian.