### PR TITLE
Fix km4ack/73Linux #61 WSJTX version check

### DIFF
--- a/app/stable/pi/WSJTX.bapp
+++ b/app/stable/pi/WSJTX.bapp
@@ -37,18 +37,18 @@ VERSION(){
 		#64bit
 	if [ `getconf LONG_BIT` = '64' ]; then
 		NEWVER=$(curl -s https://wsjt.sourceforge.io/wsjtx.html | grep arm64.deb | grep https | sed 's/.*href="//' \
-		| sed 's/.deb.*/.deb/' | awk -F "/" '{print $NF}' | sed 's/wsjtx_//' | sed 's/_arm.*//')
+		| sed 's/.deb.*/.deb/' | awk -F "/" '{print $NF}' | tail -1 | sed 's/wsjtx[-_]//;s/_arm.*//')
 
-		CURRENT=$(ls $HOME/.bap-source-files/| grep wsjtx | sed 's/wsjtx_//' | sed 's/_arm.*//')
+		CURRENT=$(ls $HOME/.bap-source-files/| grep wsjtx | tail -1 | sed 's/wsjtx[-_]//;s/_arm.*//')
 		if [ -z "$CURRENT" ]; then
 			CURRENT=0
 		fi
 	else
 		#32bit
 		NEWVER=$(curl -s https://wsjt.sourceforge.io/wsjtx.html | grep armhf | grep https | sed 's/.*href="//' \
-		| sed 's/_armhf.deb".*/_armhf.deb/' | awk -F "/" '{print $NF}' | sed 's/wsjtx_//' | sed 's/_arm.*//')
+		| sed 's/_armhf.deb".*/_armhf.deb/' | awk -F "/" '{print $NF}' | tail -1 | sed 's/wsjtx[-_]//;s/_arm.*//')
 
-		CURRENT=$(ls $HOME/.bap-source-files/| grep wsjtx | sed 's/wsjtx_//' | sed 's/_arm.*//')
+		CURRENT=$(ls $HOME/.bap-source-files/| grep wsjtx | sed 's/wsjtx[-_]//;s/_arm.*//')
 		if [ -z "$CURRENT" ]; then
 			CURRENT=0
 		fi

--- a/app/stable/x86_64/WSJTX.bapp
+++ b/app/stable/x86_64/WSJTX.bapp
@@ -49,9 +49,9 @@ REMOVE(){
 
 VERSION(){
     NEWVER=$(curl -s https://wsjt.sourceforge.io/wsjtx.html | grep amd64.deb | grep https | sed 's/.*href="//' | sed 's/.deb.*/.deb/' \
-    | awk -F "/" '{print $NF}' | sed 's/_amd.*//;s/wsjtx_//' | tail -1)
+    | awk -F "/" '{print $NF}' | sed 's/_amd.*//;s/wsjtx[-_]//' | tail -1)
 
-    CURRENT=$(ls $HOME/.bap-source-files/| grep wsjtx | sed 's/wsjtx_//' | sed 's/_amd64.deb//' | tail -1)
+    CURRENT=$(ls $HOME/.bap-source-files/| grep wsjtx | sed 's/wsjtx[-_]//' | sed 's/_amd64.deb//' | tail -1)
     if [ -z "$CURRENT" ]; then
     CURRENT=0
     fi


### PR DESCRIPTION
Fix #61 by handling WSJT-X RC naming conventions and selecting the last item on the page.