### PR TITLE
Update DIREWOLF.bapp

### DIFF
--- a/app/stable/pi/DIREWOLF.bapp
+++ b/app/stable/pi/DIREWOLF.bapp
@@ -26,7 +26,7 @@ INSTALL(){
     cd ${BUILDDIR}/direwolf || return
     mkdir build
     cd build
-    sudo apt-get install -y libasound2-dev cmake libudev-dev
+    sudo apt-get install -y libasound2-dev cmake libudev-dev libavahi-client-dev
     cmake ..
     make -j 4
     sudo make install


### PR DESCRIPTION
Add the libavahi-client library before build so that Direwolf will be built with DNS-SD enabled

Reference:
* https://github.com/dcasati/direwolf-kiss-wifi
* https://github.com/wb2osz/direwolf/releases/tag/1.7