### PR TITLE
Preserve system PATH

### DIFF
--- a/bin/runner.sh
+++ b/bin/runner.sh
@@ -300,9 +300,11 @@ EOF
 
 	#setup bin dir and put in path
 	mkdir -p ${HOME}/bin
-	CK=$(grep $HOME/bin $HOME/.bashrc)
-	if [ -z "$CK" ]; then
-		echo "export PATH=$PATH:${HOME}/bin" >>${HOME}/.bashrc
+	# Add $HOME/bin to PATH
+	# Prevent adding it more than once
+	# Prevent adding it if already added elswhere
+	if ! grep -q 'export PATH=$PATH:$HOME/bin' "${HOME}/.bashrc" && [[ ! "${PATH}" =~ "${HOME}/bin" ]]; then
+		echo 'export PATH=$PATH:$HOME/bin' >> "${HOME}/.bashrc"
 	fi
 
 	##################################


### PR DESCRIPTION
Installing 73linux on Linux Mint 22, regular means to manipulate the `PATH` variable stopped working. The reason for this was, that 73linux wrote a hard-coded version of `PATH` as part of an export into `.bashrc`.

This fix adds the PATH export only if the bin `$HOME/dir` is not already part of the PATH. It also prevents the export from being added more than once (just for good measures). And It uses an export that preserves `$PATH` as a variable to be expanded on evaluation not when added to `.bashrc`.

As a result, changes to files like `/etc/environment` and manipulation of PATH in files like `/etc/bash.bashrc` or `/etc/profile` will now be preserved. Also, on Mint 22, `.bashrc` remains untouched as `$HOME/.profile` already takes care of this.