### PR TITLE
Fix forced locale

### DIFF
--- a/73.sh
+++ b/73.sh
@@ -4,7 +4,7 @@
 # See https://github.com/km4ack/73Linux/issues/144 and https://github.com/km4ack/73Linux/issues/71.
 # 73Linux is not translated in any other languages and does change behaviour based on locale settings.
 # Forcing to use the default locale prevents any of those localization issues.
-LC_ALL=C
+export LC_ALL=C
 
 echo "#######################################"
 echo "#        Welcome to 73 Linux          #"


### PR DESCRIPTION
This is a fix for #147.

One should test even the simplest changes. I tested it on one system, but then committed the code change from another. This is where I lost the export. The export is required to persist the variable to other scripts called from this one.

Relates to #71 and #144.